### PR TITLE
Airtable Volunteer Form Opens in New Tab when Clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,8 @@ Author: Code with the Carolinas
   <hgroup></br>
     <h2>Community Resources List (Recursos Publicos): Black Mountain and Swannanoa</h2></br>
     <p><a href="http://www.blackmountainrecovery.org">Town of Black Mountain</a> &numsp;
-      <a href="https://forms.gle/J2XJuHDAWMXzx2BP6">Volunteer Application</a>
+      <a href="https://airtable.com/appaag9If4RJvGdLf/pag2UhoT0zizNnCIp/form" target="_blank" rel="noopener noreferrer">Volunteer Application</a>
+
   </hgroup>
   </br>
   <!--Mission Statement-->

--- a/index.html
+++ b/index.html
@@ -57,7 +57,9 @@ Author: Code with the Carolinas
   <hgroup></br>
     <h2>Community Resources List (Recursos Publicos): Black Mountain and Swannanoa</h2></br>
     <p><a href="http://www.blackmountainrecovery.org">Town of Black Mountain</a> &numsp;
-      <a href="https://forms.gle/J2XJuHDAWMXzx2BP6">Volunteer Application</a>
+      
+      <a href="https://forms.gle/J2XJuHDAWMXzx2BP6" target="_blank" rel="noopener noreferrer">Volunteer Application</a>
+
   </hgroup>
   </br>
   <!--Mission Statement-->


### PR DESCRIPTION
The prior setting was that when clicking on the link, the form would load on the same tab as the website so that when someone went to that form, they would not return back to the site unless they had to revisit the site.

This code now reflects that when the "Volunteer Application" is clicked on the index.html based homepage, a new tab will open with the volunteer form and the person will still have a tab open on the website.